### PR TITLE
feat: GET /api/v1/saksbehandlere/count endpoint (TEN-1560)

### DIFF
--- a/src/main/kotlin/no/nav/eux/saksbehandler/service/SaksbehandlerService.kt
+++ b/src/main/kotlin/no/nav/eux/saksbehandler/service/SaksbehandlerService.kt
@@ -16,6 +16,8 @@ class SaksbehandlerService(
     fun save(saksbehandler: Saksbehandler): Saksbehandler =
         repository.save(saksbehandler)
 
+    fun count(): Long = repository.count()
+
     fun delete(navIdent: String) {
         repository.deleteById(navIdent)
     }

--- a/src/main/kotlin/no/nav/eux/saksbehandler/webapp/controller/SaksabehandlerMapper.kt
+++ b/src/main/kotlin/no/nav/eux/saksbehandler/webapp/controller/SaksabehandlerMapper.kt
@@ -3,6 +3,7 @@ package no.nav.eux.saksbehandler.webapp.controller
 import no.nav.eux.saksbehandler.model.Saksbehandler
 import no.nav.eux.saksbehandler.webapp.model.SaksbehandlerGetApiModel
 import no.nav.eux.saksbehandler.webapp.model.SaksbehandlerPutApiModel
+import no.nav.eux.saksbehandler.webapp.model.SaksbehandlereCountGetApiModel
 
 fun SaksbehandlerPutApiModel.toEntity(navIdent: String) =
     Saksbehandler(
@@ -14,4 +15,9 @@ fun Saksbehandler.toSaksbehandlerGetApiModel() =
     SaksbehandlerGetApiModel(
         navIdent = navIdent,
         favorittEnhetNr = favorittEnhetNr,
+    )
+
+fun Long.toSaksbehandlereCountGetApiModel() =
+    SaksbehandlereCountGetApiModel(
+        antall = this,
     )

--- a/src/main/kotlin/no/nav/eux/saksbehandler/webapp/controller/SaksbehandlerController.kt
+++ b/src/main/kotlin/no/nav/eux/saksbehandler/webapp/controller/SaksbehandlerController.kt
@@ -12,6 +12,7 @@ import jakarta.validation.Valid
 import no.nav.eux.saksbehandler.service.SaksbehandlerService
 import no.nav.eux.saksbehandler.webapp.model.SaksbehandlerGetApiModel
 import no.nav.eux.saksbehandler.webapp.model.SaksbehandlerPutApiModel
+import no.nav.eux.saksbehandler.webapp.model.SaksbehandlereCountGetApiModel
 import no.nav.security.token.support.core.api.Protected
 import org.springframework.http.HttpStatus.*
 import org.springframework.http.ResponseEntity
@@ -25,6 +26,32 @@ class SaksbehandlerController(
 ) {
 
     val log = logger {}
+
+    @Operation(
+        summary = "Hent antall saksbehandlere",
+        description = "Returnerer antall registrerte saksbehandlere i systemet"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "Antall saksbehandlere",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = SaksbehandlereCountGetApiModel::class)
+                )]
+            )
+        ]
+    )
+    @GetMapping(
+        value = ["/api/v1/saksbehandlere/count"],
+        produces = ["application/json"]
+    )
+    fun countSaksbehandlere(): ResponseEntity<SaksbehandlereCountGetApiModel> {
+        val count = service.count()
+        log.info { "Antall saksbehandlere: $count" }
+        return ResponseEntity(count.toSaksbehandlereCountGetApiModel(), OK)
+    }
 
     @Operation(
         summary = "Hent saksbehandler",

--- a/src/main/kotlin/no/nav/eux/saksbehandler/webapp/model/SaksbehandlereCountGetApiModel.kt
+++ b/src/main/kotlin/no/nav/eux/saksbehandler/webapp/model/SaksbehandlereCountGetApiModel.kt
@@ -1,0 +1,10 @@
+package no.nav.eux.saksbehandler.webapp.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Antall saksbehandlere")
+data class SaksbehandlereCountGetApiModel(
+    @Schema(description = "Antall saksbehandlere", example = "42")
+    val antall: Long,
+)
+

--- a/src/test/kotlin/no/nav/eux/saksbehandler/AbstractSaksbehandlerApiImplTest.kt
+++ b/src/test/kotlin/no/nav/eux/saksbehandler/AbstractSaksbehandlerApiImplTest.kt
@@ -75,6 +75,14 @@ abstract class AbstractSaksbehandlerApiImplTest {
             httpEntity(),
             Void::class.java
         )
+
+    fun countSaksbehandlere(): ResponseEntity<String> =
+        restTemplate.exchange(
+            "/api/v1/saksbehandlere/count",
+            HttpMethod.GET,
+            httpEntity(),
+            String::class.java
+        )
 }
 
 data class SaksbehandlerPutApiModelTest(

--- a/src/test/kotlin/no/nav/eux/saksbehandler/SaksbehandlerTest.kt
+++ b/src/test/kotlin/no/nav/eux/saksbehandler/SaksbehandlerTest.kt
@@ -63,4 +63,29 @@ class SaksbehandlerTest : AbstractSaksbehandlerApiImplTest() {
         val putResponse = putSaksbehandler("6", "")
         putResponse statusCodeShouldBe 400
     }
+
+    @Test
+    fun `GET count - tom database - returnerer 0`() {
+        val countResponse = countSaksbehandlere()
+        countResponse statusCodeShouldBe 200
+        countResponse.body!! shouldEqualJson """
+            {
+              "antall": 0
+            }
+        """
+    }
+
+    @Test
+    fun `GET count - etter registrering - returnerer korrekt antall`() {
+        putSaksbehandler("1", "2950")
+        putSaksbehandler("2", "2951")
+        putSaksbehandler("3", "2952")
+        val countResponse = countSaksbehandlere()
+        countResponse statusCodeShouldBe 200
+        countResponse.body!! shouldEqualJson """
+            {
+              "antall": 3
+            }
+        """
+    }
 }


### PR DESCRIPTION
Resolves [TEN-1560](https://jira.adeo.no/browse/TEN-1560)
Closes #7

## Changes
- **Service**: Added `count()` method delegating to `JpaRepository.count()`
- **Controller**: New `GET /api/v1/saksbehandlere/count` endpoint returning `{"antall": N}` with full OpenAPI annotations. Placed before `/{navIdent}` to avoid path collision.
- **Mapper**: Added `Long.toSaksbehandlereCountGetApiModel()` extension function
- **DTO**: `SaksbehandlereCountGetApiModel` (pre-existing)
- **Tests**: Two integration tests — empty DB returns 0, correct count after registrations

## Verification
- All 8 tests pass (`mvn verify`), including 2 new count endpoint tests